### PR TITLE
Fix provider aliases in bundle environments

### DIFF
--- a/packages/cli/src/providers/providerAliases.ts
+++ b/packages/cli/src/providers/providerAliases.ts
@@ -14,7 +14,21 @@ const SUPPORTED_EXTENSIONS = new Set(['.config', '.json']);
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const BUILTIN_ALIAS_DIR = path.join(__dirname, 'aliases');
+
+// Handle different directory structures between development and bundle environments
+// In development: packages/cli/src/providers/aliases/
+// In bundle: bundle/providers/aliases/
+let BUILTIN_ALIAS_DIR: string;
+if (
+  __dirname.includes('bundle') ||
+  fs.existsSync(path.join(__dirname, 'providers'))
+) {
+  // Bundle environment: __dirname is bundle/, aliases at providers/aliases/
+  BUILTIN_ALIAS_DIR = path.join(__dirname, 'providers', 'aliases');
+} else {
+  // Development environment: __dirname is packages/cli/src/providers/, aliases at aliases/
+  BUILTIN_ALIAS_DIR = path.join(__dirname, 'aliases');
+}
 
 export type ProviderAliasSource = 'user' | 'builtin';
 


### PR DESCRIPTION
## Summary

Fix provider aliases (e.g., `--provider xAI`, `--provider Fireworks`) that were working in development but failing in bundle/production environments with "Provider not found" error.

## Root Cause

Incorrect path resolution in `providerAliases.ts` when running in bundle environments where `__dirname` differs from development.

## Changes

- **packages/cli/src/providers/providerAliases.ts**: Implemented environment-aware path resolution to correctly locate alias configuration files in both development and bundle environments
- **packages/cli/test/providers/providerAliases.pathResolution.test.ts**: Added comprehensive tests for path resolution in different environments

## Testing

- ✅ Development environment: All tests pass
- ✅ Bundle environment: Provider aliases now recognized
- ✅ Build process: Files correctly copied to npm package
- ✅ npm package: Contains all required config files

## Verification

Bundle environment test now works:
```bash
DEBUG=true node bundle/llxprt.js --provider xAI --prompt "test"
# Result: "Error when talking to xAI API" (success - provider recognized)
```

Fixes issue where provider aliases failed in production/bundle environments due to incorrect path resolution.