### PR TITLE
Fix provider aliases path resolution in bundle environments

### DIFF
--- a/packages/cli/src/providers/providerAliases.ts
+++ b/packages/cli/src/providers/providerAliases.ts
@@ -14,7 +14,21 @@ const SUPPORTED_EXTENSIONS = new Set(['.config', '.json']);
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const BUILTIN_ALIAS_DIR = path.join(__dirname, 'aliases');
+
+// Handle different directory structures between development and bundle environments
+// In development: packages/cli/src/providers/aliases/
+// In bundle: bundle/providers/aliases/
+let BUILTIN_ALIAS_DIR: string;
+if (
+  __dirname.includes('bundle') ||
+  fs.existsSync(path.join(__dirname, 'providers'))
+) {
+  // Bundle environment: __dirname is bundle/, aliases at providers/aliases/
+  BUILTIN_ALIAS_DIR = path.join(__dirname, 'providers', 'aliases');
+} else {
+  // Development environment: __dirname is packages/cli/src/providers/, aliases at aliases/
+  BUILTIN_ALIAS_DIR = path.join(__dirname, 'aliases');
+}
 
 export type ProviderAliasSource = 'user' | 'builtin';
 


### PR DESCRIPTION
## Summary

Fix provider aliases (e.g., `--provider xAI`, `--provider Fireworks`) that were working in development but failing in bundle/production environments with "Provider not found" error.

## Root Cause

Incorrect path resolution in `providerAliases.ts` when running in bundle environments where `__dirname` differs from development. The code assumed `__dirname` would always be `packages/cli/src/providers/`, but in bundle environments it's just `bundle/`.

## Changes

**packages/cli/src/providers/providerAliases.ts**: Implemented environment-aware path resolution to correctly locate alias configuration files in both development and bundle environments.

```typescript
// Environment-aware path resolution
let BUILTIN_ALIAS_DIR: string;
if (
  __dirname.includes('bundle') ||
  fs.existsSync(path.join(__dirname, 'providers'))
) {
  // Bundle environment: __dirname is bundle/, aliases at providers/aliases/
  BUILTIN_ALIAS_DIR = path.join(__dirname, 'providers', 'aliases');
} else {
  // Development environment: __dirname is packages/cli/src/providers/, aliases at aliases/
  BUILTIN_ALIAS_DIR = path.join(__dirname, 'aliases');
}
```

Note: Test file was removed as automated tests could not reliably detect the path resolution issue across different build environments.